### PR TITLE
Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang (#665)

### DIFF
--- a/__tests__/setup-go.test.ts
+++ b/__tests__/setup-go.test.ts
@@ -368,7 +368,7 @@ describe('setup-go', () => {
 
     const expPath = path.win32.join(toolPath, 'bin');
     expect(dlSpy).toHaveBeenCalledWith(
-      'https://storage.googleapis.com/golang/go1.13.1.windows-amd64.zip',
+      'https://go.dev/dl/go1.13.1.windows-amd64.zip',
       'C:\\temp\\go1.13.1.windows-amd64.zip',
       undefined
     );
@@ -922,7 +922,7 @@ use .
         const expectedUrl =
           platform === 'win32'
             ? `https://github.com/actions/go-versions/releases/download/${version}/go-${version}-${platform}-${arch}.${fileExtension}`
-            : `https://storage.googleapis.com/golang/go${version}.${osSpec}-${arch}.${fileExtension}`;
+            : `https://go.dev/dl/go${version}.${osSpec}-${arch}.${fileExtension}`;
 
         // ... but not in the local cache
         findSpy.mockImplementation(() => '');

--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -103030,7 +103030,7 @@ function getInfoFromDist(versionSpec, arch) {
         if (!version) {
             return null;
         }
-        const downloadUrl = `https://storage.googleapis.com/golang/${version.files[0].filename}`;
+        const downloadUrl = `https://go.dev/dl/${version.files[0].filename}`;
         return {
             type: 'dist',
             downloadUrl: downloadUrl,

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -315,7 +315,7 @@ async function getInfoFromDist(
     return null;
   }
 
-  const downloadUrl = `https://storage.googleapis.com/golang/${version.files[0].filename}`;
+  const downloadUrl = `https://go.dev/dl/${version.files[0].filename}`;
 
   return <IGoVersionInfo>{
     type: 'dist',


### PR DESCRIPTION
**Description:**

Pull in fix from upstream https://github.com/actions/setup-go/pull/665
* Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.